### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tools/makefile.py
+++ b/tools/makefile.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import os
 import re
 
@@ -19,13 +20,13 @@ def generate_rule(fname):
     if mtch:
       deps.append(mtch.group(1))
 
-  print "%s.o:" % base, fname,
+  print("%s.o:" % base, fname, end=' ')
   for d in deps:
-    print d,
-  print "\n"
+    print(d, end=' ')
+  print("\n")
 
 def usage(argv0):
-  print "Usage:\n", argv0, "[--prefix=path]"
+  print("Usage:\n", argv0, "[--prefix=path]")
 
 def main(argv):
 

--- a/tools/replace_header.py
+++ b/tools/replace_header.py
@@ -7,6 +7,7 @@ Typical invocation:
 
 python tools/replace_header.py src/*.[hc]pp testing/*.cpp
 """
+from __future__ import print_function
 
 import sha
 
@@ -34,7 +35,7 @@ def replace_header(filename):
 
   begin_idx = data.find(comment)
   end_idx = data.find(comment, begin_idx+1) + len(comment)
-  print begin_idx, end_idx-begin_idx, sha.sha(data[begin_idx:end_idx]).hexdigest(), filename
+  print(begin_idx, end_idx-begin_idx, sha.sha(data[begin_idx:end_idx]).hexdigest(), filename)
 
   if data[begin_idx:end_idx] != HEADER:
     fobj = open(filename, "w")

--- a/tools/tstrout.py
+++ b/tools/tstrout.py
@@ -48,7 +48,7 @@ def tokenize(expr_or_stmt):
                 print(matched.expand)
 
         else:
-            raise ValueError, repr(working_val)
+            raise ValueError(repr(working_val))
 
     return tokens
 
@@ -65,7 +65,7 @@ def cplusplus_dtype(arg):
         pre_each = tokens[1][1]
         post_each = ""
     else:
-        raise ValueError, repr(tokens)
+        raise ValueError(repr(tokens))
 
     return ((pre_all, pre_each, post_each), name)
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3. New style exceptions too.

Fixes the issues discovered in #2 