### PR TITLE
fix compilation error

### DIFF
--- a/src/ComputeResidual.cpp
+++ b/src/ComputeResidual.cpp
@@ -53,7 +53,7 @@ int ComputeResidual(const local_int_t n, const Vector & v1, const Vector & v2, d
   double local_residual = 0.0;
 
 #ifndef HPCG_NO_OPENMP
-  #pragma omp parallel default(none) shared(local_residual, v1v, v2v)
+  #pragma omp parallel shared(local_residual, v1v, v2v)
   {
     double threadlocal_residual = 0.0;
     #pragma omp for


### PR DESCRIPTION
fix compilation error in issue #4 

Same issue in official HPCG repo: 

- Removed the `default(none)` in pragma omp in a [prior commit](https://github.com/hpcg-benchmark/hpcg/commit/bcce6bad2787051db95faf7eb93db65b38b83c62).  
- Add `n` to shared list in  [commit](https://github.com/hpcg-benchmark/hpcg/commit/114602d458d1034faa52b71e4c15aba9b3a17698).  
- If we add `n` to shared list, it may cause new [issue](https://github.com/hpcg-benchmark/hpcg/issues/82).

In my test on spack gcc@7.5.0 and spack  gcc@13.2.0. _OPENMP 201511. The  [issue](https://github.com/hpcg-benchmark/hpcg/issues/82) not exists, and HPCG works wether  I add `n` to shared list.

So I prefer to remove `default(none)`, and not add `n` to shared list for now.